### PR TITLE
Add proper comment tags

### DIFF
--- a/scoped-properties/language-html-swig.cson
+++ b/scoped-properties/language-html-swig.cson
@@ -2,3 +2,5 @@
   'editor':
     'increaseIndentPattern': '\\{%\\s*(if|for|block|autoescape|macro)'
     'decreaseIndentPattern': '(else|elseif|endif|empty|endfor|endblock|endautoescape|endmacro)\\s*%\\}'
+    'commentStart': '{# '
+    'commentEnd': ' #}'

--- a/snippets/language-html-swig.cson
+++ b/snippets/language-html-swig.cson
@@ -38,3 +38,6 @@
   'block':
     'prefix': 'block'
     'body': '{% block ${1:blockname} %}\n    $0\n{% endblock %}'
+  'comment':
+    'prefix': '<!'
+    'body': '<!-- $1 -->'


### PR DESCRIPTION
Swig docs refer to the proper comment tags as `{# #}` not `<!-- -->`.
